### PR TITLE
Fix ArrowIcon transform

### DIFF
--- a/src/shared.js
+++ b/src/shared.js
@@ -139,7 +139,7 @@ function ArrowIcon({isOpen}) {
       fill="transparent"
       stroke="#979797"
       strokeWidth="1.1px"
-      transform={isOpen ? 'rotate(180)' : null}
+      transform={isOpen ? 'rotate(180)' : undefined}
     >
       <path d="M1,6 L10,15 L19,6" />
     </svg>


### PR DESCRIPTION
When using TypeScript we have this error
```
Error:(98, 7) TS2322: Type 'string | null' is not assignable to type 'string | undefined'.
  Type 'null' is not assignable to type 'string | undefined'.
```