### PR TITLE
Fixes issue with "remove on backspace"

### DIFF
--- a/src/ordered-examples/04-multi-select.js
+++ b/src/ordered-examples/04-multi-select.js
@@ -208,7 +208,7 @@ class App extends React.Component {
                   <input
                     {...getInputProps({
                       ref: this.input,
-                      onKeyUp(event) {
+                      onKeyDown(event) {
                         if (event.key === 'Backspace' && !inputValue) {
                           removeItem(selectedItems[selectedItems.length - 1])
                         }


### PR DESCRIPTION
With onKeyUp, the last item gets removed one character too early – it gets removed when there's still one character left in inputValue. This is happening because the last remaining character gets removed during the onKeyDown event, so by the time it gets to the onKeyUp event inputValue is empty, so the item gets removed. But if you check inputValue during the onKeyDown event instead, the last item gets removed at the appropriate time.