### PR TITLE
 Fix ESC key in examples

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "apollo-boost": "0.1.10",
     "axios": "0.18.0",
-    "debounce-fn": "^1.0.0",
+    "debounce-fn": "latest",
     "downshift": "^3.1.8",
     "emotion": "^9.1.3",
     "feather-icons-react": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "apollo-boost": "0.1.10",
     "axios": "0.18.0",
-    "debounce-fn": "latest",
+    "debounce-fn": "^3.0.1",
     "downshift": "^3.1.8",
     "emotion": "^9.1.3",
     "feather-icons-react": "0.2.0",

--- a/src/ordered-examples/01-basic-autocomplete.js
+++ b/src/ordered-examples/01-basic-autocomplete.js
@@ -12,7 +12,13 @@ const items = [
 
 export default () => (
   <Downshift
-    onChange={selection => alert(`You selected ${selection.value}`)}
+    onChange={selection => {
+      if (selection) {
+        alert(`You selected ${selection.value}`)
+      } else {
+        alert('selection cleared')
+      }
+    }}
     itemToString={item => (item ? item.value : '')}
   >
     {({

--- a/src/other-examples/gmail/index.js
+++ b/src/other-examples/gmail/index.js
@@ -1,5 +1,4 @@
-import React, {Component} from 'react'
-import {render} from 'react-dom'
+import React from 'react'
 import Downshift from 'downshift'
 import {List} from 'react-virtualized'
 import debounce from 'debounce-fn'

--- a/src/other-examples/prevent-reset-on-blur.js
+++ b/src/other-examples/prevent-reset-on-blur.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import {render} from 'react-dom'
 import Downshift from 'downshift'
 
 const items = [
@@ -19,7 +18,13 @@ function preventResetOnBlur(state, changes) {
 
 export default () => (
   <Downshift
-    onChange={selection => alert(`You selected ${selection.value}`)}
+    onChange={selection => {
+      if (selection) {
+        alert(`You selected ${selection.value}`)
+      } else {
+        alert('selection cleared')
+      }
+    }}
     stateReducer={preventResetOnBlur}
     itemToString={item => (item ? item.value : '')}
   >

--- a/src/other-examples/using-actions.js
+++ b/src/other-examples/using-actions.js
@@ -14,7 +14,6 @@
 //   }
 // }
 import React from 'react'
-import {render} from 'react-dom'
 import Downshift from 'downshift'
 
 const items = [
@@ -27,7 +26,13 @@ const items = [
 
 export default () => (
   <Downshift
-    onChange={selection => alert(`You selected ${selection.value}`)}
+    onChange={selection => {
+      if (selection) {
+        alert(`You selected ${selection.value}`)
+      } else {
+        alert('selection cleared')
+      }
+    }}
     itemToString={item => (item ? item.value : '')}
   >
     {({


### PR DESCRIPTION
Pressing the ESC key clears the input and calls onChange with null. Some examples did not handle this case and crash as a result. downshift-js/downshift#719

Update debounce-fn to fix gmail and axios examples